### PR TITLE
Modify flash notice for feature sad path location field [#13]

### DIFF
--- a/spec/features/user_search_for_pet_spec.rb
+++ b/spec/features/user_search_for_pet_spec.rb
@@ -33,6 +33,6 @@ describe 'user visits the home page' do
     select "cat", :from => "animal"
     click_on "Submit"
 
-    expect(page).to have_content('Location and Animal fields are required')
+    expect(page).to have_content('Location cannot be empty')
   end
 end


### PR DESCRIPTION
Pivotal URL or Waffle Card number: #13 

What does this PR do?
Update feature test to match flash notice for 'Location cannot be empty'

Where should the reviewer start? /
Any additional context you want to provide? /
Screenshots (if appropriate) / 
