### PR TITLE
Remove .search-button css to avoid conflict [#27] - closes #27

### DIFF
--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -45,20 +45,6 @@ background {
   background-color: white;
 }
 
-.search-button {
-  margin-top: 10px;
-  background-color: #410BAC;
-  border: none;
-  padding: 15px 32px;
-  text-align: center;
-  text-decoration: none;
-  display: inline-block;
-  font-size: 16px;
-  margin: 4px 2px;
-  cursor: pointer;
-  border-radius: 5px;
-}
-
 input {
   color: black;
   font-size: 14px;


### PR DESCRIPTION
Pivotal URL or Waffle Card number: #27 

What does this PR do? 
Remove from main.css the class .search-button because of conflict and inadequate styling with pet_search.

Where should the reviewer start? /
Any additional context you want to provide? /
Screenshots (if appropriate) /